### PR TITLE
Fix #36: Mention OneCRL in the bug summary

### DIFF
--- a/oneCRL/oneCRL.go
+++ b/oneCRL/oneCRL.go
@@ -373,7 +373,7 @@ func AddEntries(records *Records, createBug bool) error {
 		bug.Product = "Toolkit"
 		bug.Component = "Blocklisting"
 		bug.Version = "unspecified"
-		bug.Summary = fmt.Sprintf("CCADB entries generated %s", nowString)
+		bug.Summary = fmt.Sprintf("CCADB OneCRL entries generated %s", nowString)
 		bug.Description = conf.BugDescription
 
 		var err error


### PR DESCRIPTION
Per Kathleen's comment captured in Issue #36, change the bug summary to mention OneCRL.